### PR TITLE
Implement FileNotFoundError handling for not found PhantomJS path and so on.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,105 @@
 *.idea
 *__pycache__
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+profile_img/
+!profile_img/dygv.jpg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+beautifulsoup4==4.6.0
+olefile==0.44
+Pillow==4.2.1
+selenium==3.5.0

--- a/tool.py
+++ b/tool.py
@@ -10,7 +10,12 @@ from selenium.webdriver.support import expected_conditions as EC
 
 
 def line_profile(address, password):
-    driver = webdriver.PhantomJS("path to phantomjs.exe",
+    phantomjs_path = 'path to phantomjs.exe'
+    try:
+        f = open(phantomjs_path)
+    except FileNotFoundError as e:
+        raise
+    driver = webdriver.PhantomJS(phantomjs_path,
                                  desired_capabilities={'phantomjs.page.settings.resourceTimeout': '10000'})
 
     wait = WebDriverWait(driver, 30)


### PR DESCRIPTION
- Add requirements.txt
  - `pip install requirements.txt` This command makes it easy to install external(open source) packages.
- Update .gitignore
- When PhantomJS path doesn't found, do handling exception(`FileNotFoundError`).